### PR TITLE
Add argument type information

### DIFF
--- a/src/markey/machine.py
+++ b/src/markey/machine.py
@@ -81,7 +81,8 @@ def parse_arguments(stream, end_token):
     """
     Helper function for function argument parsing.  Pass it a
     `TokenStream` and the delimiter token for the argument section and
-    it will extract all position and keyword arguments.
+    it will extract all position and keyword arguments as well as
+    each argument's type info (string literal or not).
 
     Returns a ``(args, kwargs)`` tuple.
     """
@@ -101,9 +102,9 @@ def parse_arguments(stream, end_token):
                     kwargs[keyword] = value
                 del keywords[:]
             else:
-                args.append(value)
+                args.append((value, 'func_string_arg'))
         elif stream.current.type == 'text':
-            args.append(stream.current.value)
+            args.append((stream.current.value, 'text'))
             stream.next()
         elif stream.current.type == 'func_kwarg':
             keywords.append(stream.current.value)
@@ -113,6 +114,6 @@ def parse_arguments(stream, end_token):
         else:
             break
     for keyword in keywords:
-        args.append(keyword)
+        args.append((keyword, 'func_kwarg'))
 
     return tuple(args), kwargs

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -5,12 +5,12 @@ from markey.underscore import rules as underscore_rules
 
 
 def test_parse_arguments():
-    line = '<% gettext("some string", str="foo")'
+    line = '<% gettext(varible, "some string", str="foo")'
     stream = TokenStream.from_tuple_iter(tokenize(line, underscore_rules))
     stream.next()
     stream.next()
     stream.expect('gettext_begin')
     funcname = stream.expect('func_name').value
     args, kwargs = parse_arguments(stream, 'gettext_end')
-    assert args == ('some string',)
+    assert args == (('varible', 'text'), ('some string', 'func_string_arg'),)
     assert kwargs == {'str': 'foo'}


### PR DESCRIPTION
The parse_arguments function does not maintain argument type information.
Here a new function, parse_arguments_with_type is provided, so that each arg's type info is stored and users can easily determine whether a argument is a string literal or not.
