### PR TITLE
Prepare for 0.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.8 - 2015-08-28
+----------------
+
+ * Remove `interpolate` keyword (kosmos342)
+ * Add argument type information (louyihua)
+
 0.7 - 2015-08-28
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 
-version = '0.7'
+version = '0.8'
 
 
 def read(*parts):


### PR DESCRIPTION
@EnTeQuAk I've done you the courtesy of doing as much as I can to release a new version (since the merge of https://github.com/EnTeQuAk/django-babel-underscore/pull/4 is relying on the next version of this library!)
