### PR TITLE
Update underscore.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 
-version = '0.8'
+version = '0.9'
 
 
 def read(*parts):
@@ -78,6 +78,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
     ],

--- a/src/markey/underscore.py
+++ b/src/markey/underscore.py
@@ -47,8 +47,8 @@ rules = {
     'function_call': ruleset(
         rule(',', 'func_argument_delimiter'),
         rule('\s+', None),
-        rule(r"('([^'\\]*(?:\\.[^'\\]*)*)'|"
-             r'"([^"\\]*(?:\\.[^"\\]*)*)")(?s)', 'func_string_arg'),
+        rule(r"(?s)('([^'\\]*(?:\\.[^'\\]*)*)'|"
+             r'"([^"\\]*(?:\\.[^"\\]*)*)")', 'func_string_arg'),
         rule(r'([\w_]+)\s*=', bygroups('func_kwarg'))
     )
 }


### PR DESCRIPTION
In newer versions of Python (3.11), you can't set the global flags at positions other than the start of an expression.  Relocate the flag to the beginning of the regex.